### PR TITLE
Fix and improve image build procedure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN R -e "install.packages('batch', lib='/usr/lib/R/library', dependencies = TRU
 RUN R -e "source('http://bioconductor.org/biocLite.R') ; biocLite('ropls')"
 
 # Clone tool
-RUN git clone -b master https://github.com/workflow4metabolomics/multivariate /files/multivariate
+RUN git clone -b v2.3.6 https://github.com/workflow4metabolomics/multivariate.git /files/multivariate
 
 # Make it executable
 RUN chmod a+rx /files/multivariate/multivariate_wrapper.R && cp /files/multivariate/multivariate_wrapper.R /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,13 @@ FROM ubuntu:14.04
 
 MAINTAINER Etienne Thevenot (etienne.thevenot@cea.fr)
 
-# Setup package repos
-#RUN echo "deb http://mirrors.ebi.ac.uk/CRAN/bin/linux/ubuntu trusty/" >> /etc/apt/sources.list
-RUN echo "deb http://cran.univ-paris1.fr/bin/linux/ubuntu trusty/" >> /etc/apt/sources.list
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
-
 # Update and upgrade system
-RUN apt-get update
-RUN apt-get -y upgrade
+RUN apt-get update \
+    && apt-get -y upgrade \
+    && apt-get -y install r-base git \
+    && apt-get clean && apt-get autoremove -y && rm -rf /var/lib/{apt,dpkg,cache,log}/ /tmp/* /var/tmp/*
 
 # Install R and other needed packages
-RUN apt-get -y install r-base
 RUN R -e "install.packages('batch', lib='/usr/lib/R/library', dependencies = TRUE, repos='http://mirrors.ebi.ac.uk/CRAN')"
 RUN R -e "source('http://bioconductor.org/biocLite.R') ; biocLite('ropls')"
 
@@ -21,9 +17,6 @@ RUN git clone -b master https://github.com/workflow4metabolomics/multivariate /f
 
 # Make it executable
 RUN chmod a+rx /files/multivariate/multivariate_wrapper.R && cp /files/multivariate/multivariate_wrapper.R /usr/local/bin/
-
-# Clean up
-RUN apt-get clean && apt-get autoremove -y && rm -rf /var/lib/{apt,dpkg,cache,log}/ /tmp/* /var/tmp/*
 
 # Define Entry point script
 ENTRYPOINT ["/files/multivariate/multivariate_wrapper.R"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,17 @@ FROM ubuntu:14.04
 
 MAINTAINER Etienne Thevenot (etienne.thevenot@cea.fr)
 
-# Update and upgrade system
-RUN apt-get update \
-    && apt-get -y upgrade \
-    && apt-get -y install r-base git \
-    && apt-get clean && apt-get autoremove -y && rm -rf /var/lib/{apt,dpkg,cache,log}/ /tmp/* /var/tmp/*
+# Install tool and its dependencies packages
+RUN \
+     apt-get update  \
+  && apt-get -y install --no-install-recommends \
+       git \
+       liblwp-protocol-https-perl \
+       r-base \
+  && R -e "install.packages('batch', lib='/usr/lib/R/library', dependencies = TRUE, repos='http://mirrors.ebi.ac.uk/CRAN')"  \
+  && R -e "source('http://bioconductor.org/biocLite.R') ; biocLite('ropls')"  \
+  && apt-get clean && apt-get autoremove -y && rm -rf /var/lib/{apt,dpkg,cache,log}/ /tmp/* /var/tmp/*
 
-# Install R and other needed packages
-RUN R -e "install.packages('batch', lib='/usr/lib/R/library', dependencies = TRUE, repos='http://mirrors.ebi.ac.uk/CRAN')"
-RUN R -e "source('http://bioconductor.org/biocLite.R') ; biocLite('ropls')"
 
 # Clone tool
 RUN git clone -b v2.3.6 https://github.com/workflow4metabolomics/multivariate.git /files/multivariate

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,7 @@ RUN R -e "install.packages('batch', lib='/usr/lib/R/library', dependencies = TRU
 RUN R -e "source('http://bioconductor.org/biocLite.R') ; biocLite('ropls')"
 
 # Clone tool
-RUN apt-get -y install git
-RUN git clone -b 2.3.6 https://github.com/workflow4metabolomics/multivariate /files/multivariate
+RUN git clone -b master https://github.com/workflow4metabolomics/multivariate /files/multivariate
 
 # Make it executable
 RUN chmod a+rx /files/multivariate/multivariate_wrapper.R && cp /files/multivariate/multivariate_wrapper.R /usr/local/bin/


### PR DESCRIPTION
This  PR changes two things.  The old procedure tried to check out an inexistent tag in the multivariate tool -- it now checks out the `master`.  The second change makes the image build procedure more efficient by doing almost all software installation in a single `RUN` statement, reducing the number of layers in the resulting image.